### PR TITLE
More robust isiterabletable

### DIFF
--- a/src/TableTraits.jl
+++ b/src/TableTraits.jl
@@ -7,6 +7,10 @@ export supports_get_columns_copy, get_columns_copy
 export supports_get_columns_copy_using_missing, get_columns_copy_using_missing
 export supports_get_columns_view, get_columns_view
 
+# Taken from Setfield.jl
+@generated constructor_of(::Type{T}) where T =
+    getfield(parentmodule(T), nameof(T))
+
 # Iterable table trait
 
 function isiterabletable(x::T) where {T}
@@ -14,7 +18,7 @@ function isiterabletable(x::T) where {T}
 
     if Base.IteratorEltype(x)==Base.HasEltype()
         et = Base.eltype(x)
-        if et <: NamedTuple
+        if constructor_of(et) === NamedTuple
             return true
         elseif et===Any
             return missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ other_array = [1,2,3]
 without_eltype = (i for i in table_array)
 
 @test isiterabletable(table_array)
+@test isiterabletable((NamedTuple{(:x, :y), T} where T)[(x=1, y=1)])
 @test !isiterabletable(other_array)
 @test isiterabletable(without_eltype)===missing
 @test isiterabletable(any_table_array)===missing


### PR DESCRIPTION
Before:

```julia
julia> TableTraits.isiterabletable((NamedTuple{(:x, :y), T} where T)[(x=1, y=1)])
false
```

After:

```julia
julia> TableTraits.isiterabletable((NamedTuple{(:x, :y), T} where T)[(x=1, y=1)])
true
```