### PR TITLE
Fix Union{} corner case in isiterabletable

### DIFF
--- a/src/TableTraits.jl
+++ b/src/TableTraits.jl
@@ -14,9 +14,11 @@ function isiterabletable(x::T) where {T}
 
     if Base.IteratorEltype(x)==Base.HasEltype()
         et = Base.eltype(x)
-        if et <: NamedTuple
+        if et === Union{}
+            return false
+        elseif et <: NamedTuple
             return true
-        elseif et===Any
+        elseif et === Any
             return missing
         else
             return false

--- a/src/TableTraits.jl
+++ b/src/TableTraits.jl
@@ -18,7 +18,7 @@ function isiterabletable(x::T) where {T}
             return false
         elseif et <: NamedTuple
             return true
-        elseif et === Any
+        elseif et===Any
             return missing
         else
             return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,5 +16,6 @@ without_eltype = (i for i in table_array)
 @test !supports_get_columns_copy(table_array)
 @test !supports_get_columns_view(table_array)
 @test !supports_get_columns_copy_using_missing(table_array)
+@test isiterabletable(Union{}[]) == false
 
 end


### PR DESCRIPTION
This is a corner case as `Union{} <: NamedTuple` but I guess you do not want to support `Union{}` eltype to be `true` in this test?